### PR TITLE
new feature: apply OCR to uploaded pdfs

### DIFF
--- a/core/services/service_upload/js/service_upload.js
+++ b/core/services/service_upload/js/service_upload.js
@@ -5,11 +5,11 @@
 
 
 // import
-	import {event_manager} from '../../../common/js/event_manager.js'
-	import {data_manager} from '../../../common/js/data_manager.js'
-	import {dd_console} from '../../../common/js/utils/index.js'
-	import {common} from '../../../common/js/common.js'
-	import {render_edit_service_upload} from './render_edit_service_upload.js'
+import {event_manager} from '../../../common/js/event_manager.js'
+import {data_manager} from '../../../common/js/data_manager.js'
+import {dd_console} from '../../../common/js/utils/index.js'
+import {common} from '../../../common/js/common.js'
+import {render_edit_service_upload} from './render_edit_service_upload.js'
 
 
 
@@ -20,18 +20,18 @@
 */
 export const service_upload = function () {
 
-	this.id					= null
-	this.model				= null
-	this.mode				= null
-	this.node				= null
-	this.ar_instances		= null
-	this.status				= null
-	this.events_tokens		= null
-	this.type				= null
-	this.caller				= null
+this.id					= null
+this.model				= null
+this.mode				= null
+this.node				= null
+this.ar_instances		= null
+this.status				= null
+this.events_tokens		= null
+this.type				= null
+this.caller				= null
 
-	this.max_size_bytes		= null
-	this.allowed_extensions	= null
+this.max_size_bytes		= null
+this.allowed_extensions	= null
 }//end page
 
 
@@ -41,10 +41,10 @@ export const service_upload = function () {
 * extend functions from common
 */
 // prototypes assign
-	service_upload.prototype.render		= common.prototype.render
-	service_upload.prototype.destroy	= common.prototype.destroy
-	service_upload.prototype.refresh	= common.prototype.refresh
-	service_upload.prototype.edit		= render_edit_service_upload.prototype.edit
+service_upload.prototype.render		= common.prototype.render
+service_upload.prototype.destroy	= common.prototype.destroy
+service_upload.prototype.refresh	= common.prototype.refresh
+service_upload.prototype.edit		= render_edit_service_upload.prototype.edit
 
 
 
@@ -55,57 +55,57 @@ export const service_upload = function () {
 */
 service_upload.prototype.init = async function(options) {
 
-	const self = this
+const self = this
 
-	// call the generic common init
-		const common_init = await common.prototype.init.call(this, options);
+// call the generic common init
+	const common_init = await common.prototype.init.call(this, options);
 
-	// fix
-		self.model				= options.model || 'service_upload'
-		self.allowed_extensions	= options.allowed_extensions || []
-		self.key_dir			= options.key_dir || null
+// fix
+	self.model				= options.model || 'service_upload'
+	self.allowed_extensions	= options.allowed_extensions || []
+	self.key_dir			= options.key_dir || null
 
-	// check
-		if (!self.caller) {
-			console.error('Caller is mandatory for service_upload:', self);
-		}
+// check
+	if (!self.caller) {
+		console.error('Caller is mandatory for service_upload:', self);
+	}
 
-	// events
-		self.events_tokens.push(
-			event_manager.subscribe('upload_file_status_'+self.id, fn_update_file_status)
-		)
-		function fn_update_file_status(options) {
+// events
+	self.events_tokens.push(
+		event_manager.subscribe('upload_file_status_'+self.id, fn_update_file_status)
+	)
+	function fn_update_file_status(options) {
 
-			// options
-				const msg	= options.msg
-				const value	= options.value
+		// options
+			const msg	= options.msg
+			const value	= options.value
 
-			// DOM node fixed on render
-				const progress_info	= self.progress_info
-				const progress_line	= self.progress_line
-				const response_msg	= self.response_msg
+		// DOM node fixed on render
+			const progress_info	= self.progress_info
+			const progress_line	= self.progress_line
+			const response_msg	= self.response_msg
 
-			// progress
-				if (progress_info) {
-					progress_info.innerHTML	= msg // progress text info
+		// progress
+			if (progress_info) {
+				progress_info.innerHTML	= msg // progress text info
+			}
+			if (progress_line) {
+				progress_line.value = value // percentage line
+			}
+
+		// messages
+			if (response_msg) {
+				if(value===false) {
+					response_msg.innerHTML = msg
 				}
-				if (progress_line) {
-					progress_line.value = value // percentage line
+				else if(value===100) {
+					response_msg.innerHTML = 'Upload done.'
 				}
-
-			// messages
-				if (response_msg) {
-					if(value===false) {
-						response_msg.innerHTML = msg
-					}
-					else if(value===100) {
-						response_msg.innerHTML = 'Upload done.'
-					}
-				}
-		}
+			}
+	}
 
 
-	return common_init
+return common_init
 }//end init
 
 
@@ -117,20 +117,20 @@ service_upload.prototype.init = async function(options) {
 */
 service_upload.prototype.build = async function(autoload=false) {
 
-	const self = this
+const self = this
 
-	// fetch system info
-		const system_info = await get_system_info(self)
-		// set as tool properties
-			self.max_size_bytes				= system_info.max_size_bytes
-			self.sys_get_temp_dir			= system_info.sys_get_temp_dir
-			self.upload_tmp_dir				= system_info.upload_tmp_dir
-			self.upload_tmp_perms			= system_info.upload_tmp_perms
-			self.session_cache_expire		= system_info.session_cache_expire
-			self.upload_service_chunk_files	= system_info.upload_service_chunk_files
+// fetch system info
+	const system_info = await get_system_info(self)
+	// set as tool properties
+		self.max_size_bytes				= system_info.max_size_bytes
+		self.sys_get_temp_dir			= system_info.sys_get_temp_dir
+		self.upload_tmp_dir				= system_info.upload_tmp_dir
+		self.upload_tmp_perms			= system_info.upload_tmp_perms
+		self.session_cache_expire		= system_info.session_cache_expire
+		self.upload_service_chunk_files	= system_info.upload_service_chunk_files
 
 
-	return true
+return true
 }//end build_custom
 
 
@@ -143,28 +143,28 @@ service_upload.prototype.build = async function(autoload=false) {
 */
 const get_system_info = async function() {
 
-	// rqo
-		const rqo = {
-			dd_api	: 'dd_utils_api',
-			action	: 'get_system_info'
-		}
+// rqo
+	const rqo = {
+		dd_api	: 'dd_utils_api',
+		action	: 'get_system_info'
+	}
 
-	// call to the API, fetch data and get response
-		return new Promise(function(resolve){
+// call to the API, fetch data and get response
+	return new Promise(function(resolve){
 
-			data_manager.request({
-				body : rqo
-			})
-			.then(function(response){
-				if(SHOW_DEVELOPER===true) {
-					dd_console("-> get_system_info API response:",'DEBUG',response);
-				}
-
-				const result = response.result
-
-				resolve(result)
-			})
+		data_manager.request({
+			body : rqo
 		})
+		.then(function(response){
+			if(SHOW_DEVELOPER===true) {
+				dd_console("-> get_system_info API response:",'DEBUG',response);
+			}
+
+			const result = response.result
+
+			resolve(result)
+		})
+	})
 }//end get_system_info
 
 
@@ -176,366 +176,366 @@ const get_system_info = async function() {
 */
 export const upload = async function(options) {
 
-	// options
-		const id					= options.id // id done by the caller, used to send the events of progress
-		const file					= options.file // object {name:'xxx.jpg',size:5456456}
-		const key_dir				= options.key_dir // object {type: 'dedalo_config', value: 'DEDALO_TOOL_IMPORT_DEDALO_CSV_FOLDER_PATH'}
-		const allowed_extensions	= options.allowed_extensions // array ['tiff', 'jpeg']
-		const max_size_bytes		= options.max_size_bytes // int 352142
-		const tipo					= options.tipo // self.caller.caller.tipo, like service_upload.tool_upload.component_image.tipo
+// options
+	const id					= options.id // id done by the caller, used to send the events of progress
+	const file					= options.file // object {name:'xxx.jpg',size:5456456}
+	const key_dir				= options.key_dir // object {type: 'dedalo_config', value: 'DEDALO_TOOL_IMPORT_DEDALO_CSV_FOLDER_PATH'}
+	const allowed_extensions	= options.allowed_extensions // array ['tiff', 'jpeg']
+	const max_size_bytes		= options.max_size_bytes // int 352142
+	const tipo					= options.tipo // self.caller.caller.tipo, like service_upload.tool_upload.component_image.tipo
 
 
-	return new Promise(function(resolve){
+return new Promise(function(resolve){
 
-		// short vars
-			const api_url	= DEDALO_API_URL
-			const response	= {
-				result : false
+	// short vars
+		const api_url	= DEDALO_API_URL
+		const response	= {
+			result : false
+		}
+
+	// check file extension
+		const file_extension = file.name.split('.').pop().toLowerCase();
+		if (!allowed_extensions.includes(file_extension)) {
+			alert( get_label.invalid_extension + ": \n" + file_extension + "\nUse any of: \n" + JSON.stringify(allowed_extensions) );
+			resolve(response)
+			return false
+		}
+
+	// check max file size
+		const file_size_bytes = file.size
+		if (file_size_bytes>max_size_bytes) {
+			alert( get_label.filesize_is_too_big + " Max file size is " + Math.floor(max_size_bytes / (1024*1024)) + " MB and current file is " + Math.floor(file_size_bytes / (1024*1024)));
+			resolve(response)
+			return false
+		}
+
+	// FormData build
+		// 	const fd = new FormData();
+		// 	fd.append('key_dir',		key_dir);
+		// 	// fd.append('allowed_extensions', 	JSON.stringify(allowed_extensions));
+		// 	// file
+		// 	fd.append('fileToUpload', file);
+
+	// upload_loadstart
+		const upload_loadstart = function() {
+			// progress_line.value		= 0;
+			// response_msg.innerHTML	= '<span class="blink">Loading file '+file.name+'</span>'
+			event_manager.publish('upload_file_status_'+id, {
+				value	: 0,
+				msg		: 'Loading file ' + file.name
+			})
+		}//end upload_loadstart
+
+	// upload_load.(finished)
+		const upload_load = function() {
+			// response_msg.innerHTML = '<span class="blink">Processing file '+file.name+'</span>'
+			event_manager.publish('upload_file_status_'+id, {
+				value	: 100,
+				msg		: 'Loaded file ' + file.name
+			})
+		}//end upload_load
+
+	// upload_error
+		const upload_error = function() {
+			// response_msg.innerHTML = `<span class="error">${get_label.error_on_upload_file} ${file.name}</span>`
+			event_manager.publish('upload_file_status_'+id, {
+				value	: false,
+				msg		: `${get_label.error_on_upload_file} ${file.name}`
+			})
+		}//end upload_error
+
+	// upload_abort
+		const upload_abort = function() {
+			// response_msg.innerHTML = '<span class="error">User aborts upload</span>'
+			event_manager.publish('upload_file_status_'+id, {
+				value	: false,
+				msg		: `User aborts upload`
+			})
+		}//end upload_abort
+
+	// upload_progress
+		const loaded = []
+		const upload_progress = function(options) {
+
+			const event			= options.event
+			const chunk_index	= options.chunk_index
+			const total_chunks	= options.total_chunks
+
+			const current_chunk_loaded = parseInt(event.loaded/event.total*100);
+			loaded[chunk_index] = current_chunk_loaded;
+			const sum = loaded.reduce((first, second) => first + second);
+
+			const percent = Math.round(sum/total_chunks);
+			// info line show numerical percentage of load
+			event_manager.publish('upload_file_status_'+id, {
+				value	: percent,
+				msg		: `Upload progress: ${percent} %`
+			})
+			if(percent === 100){
+				upload_load()
 			}
+		}//end upload_progress
 
-		// check file extension
-			const file_extension = file.name.split('.').pop().toLowerCase();
-			if (!allowed_extensions.includes(file_extension)) {
-				alert( get_label.invalid_extension + ": \n" + file_extension + "\nUse any of: \n" + JSON.stringify(allowed_extensions) );
-				resolve(response)
-				return false
-			}
+	// xhr_load
+		const files_chunked		= []
+		const count_uploaded	= []
+		const xhr_load = function(evt) {
 
-		// check max file size
-			const file_size_bytes = file.size
-			if (file_size_bytes>max_size_bytes) {
-				alert( get_label.filesize_is_too_big + " Max file size is " + Math.floor(max_size_bytes / (1024*1024)) + " MB and current file is " + Math.floor(file_size_bytes / (1024*1024)));
-				resolve(response)
-				return false
-			}
+			// parse response string as JSON
+				// let response = null
+				// try {
+					const api_response = JSON.parse(evt.target.response);
 
-		// FormData build
-			// 	const fd = new FormData();
-			// 	fd.append('key_dir',		key_dir);
-			// 	// fd.append('allowed_extensions', 	JSON.stringify(allowed_extensions));
-			// 	// file
-			// 	fd.append('fileToUpload', file);
-
-		// upload_loadstart
-			const upload_loadstart = function() {
-				// progress_line.value		= 0;
-				// response_msg.innerHTML	= '<span class="blink">Loading file '+file.name+'</span>'
-				event_manager.publish('upload_file_status_'+id, {
-					value	: 0,
-					msg		: 'Loading file ' + file.name
-				})
-			}//end upload_loadstart
-
-		// upload_load.(finished)
-			const upload_load = function() {
-				// response_msg.innerHTML = '<span class="blink">Processing file '+file.name+'</span>'
-				event_manager.publish('upload_file_status_'+id, {
-					value	: 100,
-					msg		: 'Loaded file ' + file.name
-				})
-			}//end upload_load
-
-		// upload_error
-			const upload_error = function() {
-				// response_msg.innerHTML = `<span class="error">${get_label.error_on_upload_file} ${file.name}</span>`
-				event_manager.publish('upload_file_status_'+id, {
-					value	: false,
-					msg		: `${get_label.error_on_upload_file} ${file.name}`
-				})
-			}//end upload_error
-
-		// upload_abort
-			const upload_abort = function() {
-				// response_msg.innerHTML = '<span class="error">User aborts upload</span>'
-				event_manager.publish('upload_file_status_'+id, {
-					value	: false,
-					msg		: `User aborts upload`
-				})
-			}//end upload_abort
-
-		// upload_progress
-			const loaded = []
-			const upload_progress = function(options) {
-
-				const event			= options.event
-				const chunk_index	= options.chunk_index
-				const total_chunks	= options.total_chunks
-
-				const current_chunk_loaded = parseInt(event.loaded/event.total*100);
-				loaded[chunk_index] = current_chunk_loaded;
-				const sum = loaded.reduce((first, second) => first + second);
-
-				const percent = Math.round(sum/total_chunks);
-				// info line show numerical percentage of load
-			    event_manager.publish('upload_file_status_'+id, {
-					value	: percent,
-					msg		: `Upload progress: ${percent} %`
-				})
-				if(percent === 100){
-					upload_load()
-				}
-			}//end upload_progress
-
-		// xhr_load
-			const files_chunked		= []
-			const count_uploaded	= []
-			const xhr_load = function(evt) {
-
-				// parse response string as JSON
-					// let response = null
-					// try {
-						const api_response = JSON.parse(evt.target.response);
-
-						if (!api_response) {
-							console.error("Error in XMLHttpRequest load response. Invalid response is received");
-							resolve(response)
-							return false
-						}
-						// debug
-							if(SHOW_DEBUG===true) {
-								// console.log("upload_file.XMLHttpRequest load response:", api_response);
-							}
-
-						// check if the file uploaded is a chunk
-						const file_data = api_response.file_data
-						// if upload is chunked is necessary join the files in the server before resolve the upload
-						if(file_data.chunked){
-							// get the index
-							const chunk_index = file_data.chunk_index
-
-							files_chunked[chunk_index] = file_data.tmp_name
-							count_uploaded.push(file_data.chunk_index)
-							// get filename of every chunk
-							const total_chunks = parseInt( file_data.total_chunks)
-							// finished upload all chunks
-							if(count_uploaded.length === total_chunks){
-
-								service_upload.prototype.join_chunked_files({
-									file_data		: file_data,
-									files_chunked	: files_chunked
-								}).then(function(api_response){
-
-									resolve(api_response) //api_response
-									return true
-								})
-							}
-
-						}else{
-							resolve(api_response) //api_response
-							return true
+					if (!api_response) {
+						console.error("Error in XMLHttpRequest load response. Invalid response is received");
+						resolve(response)
+						return false
+					}
+					// debug
+						if(SHOW_DEBUG===true) {
+							// console.log("upload_file.XMLHttpRequest load response:", api_response);
 						}
 
+					// check if the file uploaded is a chunk
+					const file_data = api_response.file_data
+					// if upload is chunked is necessary join the files in the server before resolve the upload
+					if(file_data.chunked){
+						// get the index
+						const chunk_index = file_data.chunk_index
 
-					// } catch (error) {
-						// alert(evt.target.response)
-						// console.warn("response:",evt.target.response);
-						// console.error(error)
+						files_chunked[chunk_index] = file_data.tmp_name
+						count_uploaded.push(file_data.chunk_index)
+						// get filename of every chunk
+						const total_chunks = parseInt( file_data.total_chunks)
+						// finished upload all chunks
+						if(count_uploaded.length === total_chunks){
 
-						// resolve(response)
-						// return false
-					// }
+							service_upload.prototype.join_chunked_files({
+								file_data		: file_data,
+								files_chunked	: files_chunked
+							}).then(function(api_response){
 
-				// print message
-					// response_msg.innerHTML = response.msg
+								resolve(api_response) //api_response
+								return true
+							})
+						}
 
-			}//end xhr_load
+					}else{
+						resolve(api_response) //api_response
+						return true
+					}
 
-		// chunk_file
-			const chunk_file = function (file) {
 
-				const file_size		= file.size;
-				//break into xMB chunks
-				const size			= DEDALO_UPLOAD_SERVICE_CHUNK_FILES || 80; // maximum size for chunks
-				const chunk_size	= size*1024*1024;
-				let start			= 0;
-				const total_chunks	= Math.ceil(file_size / chunk_size);
+				// } catch (error) {
+					// alert(evt.target.response)
+					// console.warn("response:",evt.target.response);
+					// console.error(error)
 
-				for (let i = 0; i < total_chunks; i++) {
+					// resolve(response)
+					// return false
+				// }
 
-					const check_end = start + chunk_size
-					const end = (file_size - check_end < 0)
-						? file_size
-						: check_end;
-					const chunk = slice(file, start, end);
+			// print message
+				// response_msg.innerHTML = response.msg
 
-					send_chunk({
-						chunk			: chunk,
-						chunk_index		: i,
-						total_chunks	: total_chunks,
-						start			: start,
-						end				: end,
-						file_size		: file_size
-					});
+		}//end xhr_load
 
-					start += chunk_size;
-				}
+	// chunk_file
+		const chunk_file = function (file) {
+
+			const file_size		= file.size;
+			//break into xMB chunks
+			const size			= DEDALO_UPLOAD_SERVICE_CHUNK_FILES || 80; // maximum size for chunks
+			const chunk_size	= size*1024*1024;
+			let start			= 0;
+			const total_chunks	= Math.ceil(file_size / chunk_size);
+
+			for (let i = 0; i < total_chunks; i++) {
+
+				const check_end = start + chunk_size
+				const end = (file_size - check_end < 0)
+					? file_size
+					: check_end;
+				const chunk = slice(file, start, end);
+
+				send_chunk({
+					chunk			: chunk,
+					chunk_index		: i,
+					total_chunks	: total_chunks,
+					start			: start,
+					end				: end,
+					file_size		: file_size
+				});
+
+				start += chunk_size;
 			}
+		}
 
-		// slice the file
-			function slice(file, start, end) {
-				const slice = file.mozSlice
-					? file.mozSlice
-					: file.webkitSlice
-						? file.webkitSlice
-						: file.slice
-							? file.slice
-							: function(){};
+	// slice the file
+		function slice(file, start, end) {
+			const slice = file.mozSlice
+				? file.mozSlice
+				: file.webkitSlice
+					? file.webkitSlice
+					: file.slice
+						? file.slice
+						: function(){};
 
-				return slice.bind(file)(start, end);
-			}
+			return slice.bind(file)(start, end);
+		}
 
-		// send the chunk files to server
-			function send_chunk(options) {
+	// send the chunk files to server
+		function send_chunk(options) {
 
-				const chunked 		= true
-				const chunk			= options.chunk
-				const chunk_index	= options.chunk_index
-				const total_chunks	= options.total_chunks
-				const start			= options.start
-				const end			= options.end
-				const file_size		= options.file_size
+			const chunked 		= true
+			const chunk			= options.chunk
+			const chunk_index	= options.chunk_index
+			const total_chunks	= options.total_chunks
+			const start			= options.start
+			const end			= options.end
+			const file_size		= options.file_size
 
-				const formdata = new FormData();
-				const xhr = new XMLHttpRequest();
+			const formdata = new FormData();
+			const xhr = new XMLHttpRequest();
 
-				xhr.open('POST', api_url, true);
+			xhr.open('POST', api_url, true);
 
-				const chunk_end = end-1;
+			const chunk_end = end-1;
 
-				// Content-Range: bytes 0-999999/4582884
-				const contentRange = "bytes "+ start +"-"+ chunk_end +"/"+ file_size;
-				xhr.setRequestHeader("Content-Range",contentRange);
+			// Content-Range: bytes 0-999999/4582884
+			const contentRange = "bytes "+ start +"-"+ chunk_end +"/"+ file_size;
+			xhr.setRequestHeader("Content-Range",contentRange);
 
-				// request header
-				xhr.setRequestHeader("X-File-Name", encodeURIComponent(file.name));
+			// request header
+			xhr.setRequestHeader("X-File-Name", encodeURIComponent(file.name));
 
-					formdata.append('key_dir', key_dir);
-					formdata.append('file_name', file.name);
-					formdata.append('chunked', chunked);
-					formdata.append('start', start);
-					formdata.append('end', end);
-					formdata.append('chunk_index', chunk_index);
-					formdata.append('total_chunks', total_chunks);
-					formdata.append('file_to_upload', chunk);
+				formdata.append('key_dir', key_dir);
+				formdata.append('file_name', file.name);
+				formdata.append('chunked', chunked);
+				formdata.append('start', start);
+				formdata.append('end', end);
+				formdata.append('chunk_index', chunk_index);
+				formdata.append('total_chunks', total_chunks);
+				formdata.append('file_to_upload', chunk);
 
-				// upload_loadstart (the upload begins)
-					xhr.upload.addEventListener("loadstart", upload_loadstart, false);
+			// upload_loadstart (the upload begins)
+				xhr.upload.addEventListener("loadstart", upload_loadstart, false);
 
-				// upload_error (the upload ends in error)
-					// xhr.upload.addEventListener("error", upload_error, false);
-					xhr.upload.addEventListener("error", function(evt) {
-						upload_error(evt)
-						console.error('evt:', evt);
-						console.log('chunk:', chunk);
-						// clearInterval(intervalTimer);
-						setTimeout(function(){
-							send_chunk(options)
-						}, 5000)
-					}, false);
+			// upload_error (the upload ends in error)
+				// xhr.upload.addEventListener("error", upload_error, false);
+				xhr.upload.addEventListener("error", function(evt) {
+					upload_error(evt)
+					console.error('evt:', evt);
+					console.log('chunk:', chunk);
+					// clearInterval(intervalTimer);
+					setTimeout(function(){
+						send_chunk(options)
+					}, 5000)
+				}, false);
 
-				// upload_abort (the upload has been aborted by the user)
-					xhr.upload.addEventListener("abort", upload_abort, false);
+			// upload_abort (the upload has been aborted by the user)
+				xhr.upload.addEventListener("abort", upload_abort, false);
 
-				// progress
-					xhr.upload.addEventListener("progress", function(event) {
-						 upload_progress({
-							event			: event,
-							chunk_index		: chunk_index,
-							total_chunks	: total_chunks
-						 })
-					}, false);
+			// progress
+				xhr.upload.addEventListener("progress", function(event) {
+					 upload_progress({
+						event			: event,
+						chunk_index		: chunk_index,
+						total_chunks	: total_chunks
+					 })
+				}, false);
 
-				// xhr_load (the XMLHttpRequest ends successfully)
-					xhr.addEventListener("load", xhr_load, false);
+			// xhr_load (the XMLHttpRequest ends successfully)
+				xhr.addEventListener("load", xhr_load, false);
 
-				xhr.send(formdata);
-			}//end send_chunk
+			xhr.send(formdata);
+		}//end send_chunk
 
-		// send the entire file to server
-			function send(options) {
+	// send the entire file to server
+		function send(options) {
 
-				const chunked = false
+			const chunked = false
 
-				const formdata = new FormData();
-				const xhr = new XMLHttpRequest();
+			const formdata = new FormData();
+			const xhr = new XMLHttpRequest();
 
-				xhr.open('POST', api_url, true);
+			xhr.open('POST', api_url, true);
 
-				// request header
-				xhr.setRequestHeader("X-File-Name", encodeURIComponent(file.name));
+			// request header
+			xhr.setRequestHeader("X-File-Name", encodeURIComponent(file.name));
 
-					formdata.append('key_dir', key_dir);
-					formdata.append('file_name', file.name);
-					formdata.append('chunked', chunked);
-					formdata.append('file_to_upload', file);
-					formdata.append('tipo', tipo);
+				formdata.append('key_dir', key_dir);
+				formdata.append('file_name', file.name);
+				formdata.append('chunked', chunked);
+				formdata.append('file_to_upload', file);
+				formdata.append('tipo', tipo);
 
-				// upload_load file (the upload ends successfully)
-					// xhr.upload.addEventListener("load", upload_load, false);
+			// upload_load file (the upload ends successfully)
+				// xhr.upload.addEventListener("load", upload_load, false);
 
-				// upload_loadstart (the upload begins)
-					xhr.upload.addEventListener("loadstart", upload_loadstart, false);
+			// upload_loadstart (the upload begins)
+				xhr.upload.addEventListener("loadstart", upload_loadstart, false);
 
-				// upload_error (the upload ends in error)
-					xhr.upload.addEventListener("error", upload_error, false);
+			// upload_error (the upload ends in error)
+				xhr.upload.addEventListener("error", upload_error, false);
 
-				// upload_abort (the upload has been aborted by the user)
-					xhr.upload.addEventListener("abort", upload_abort, false);
+			// upload_abort (the upload has been aborted by the user)
+				xhr.upload.addEventListener("abort", upload_abort, false);
 
-				// progress
-					xhr.upload.addEventListener("progress", function(event){
-						 upload_progress({
-							event			: event,
-							chunk_index		: 1,
-							total_chunks	: 1
-						 })
-					}, false);
+			// progress
+				xhr.upload.addEventListener("progress", function(event){
+					 upload_progress({
+						event			: event,
+						chunk_index		: 1,
+						total_chunks	: 1
+					 })
+				}, false);
 
-				// xhr_load (the XMLHttpRequest ends successfully)
-					xhr.addEventListener("load", xhr_load, false);
+			// xhr_load (the XMLHttpRequest ends successfully)
+				xhr.addEventListener("load", xhr_load, false);
 
-				xhr.send(formdata);
-			}
+			xhr.send(formdata);
+		}
 
-		// chunk_file on end, else send next chunk
-			if (DEDALO_UPLOAD_SERVICE_CHUNK_FILES > 0) {
-				chunk_file(file, key_dir)
-			}else{
-				send()
-			}
+	// chunk_file on end, else send next chunk
+		if (DEDALO_UPLOAD_SERVICE_CHUNK_FILES > 0) {
+			chunk_file(file, key_dir)
+		}else{
+			send()
+		}
 
-		// XMLHttpRequest
-			// 		const xhr = new XMLHttpRequest();
+	// XMLHttpRequest
+		// 		const xhr = new XMLHttpRequest();
 
-			// 		// upload
-			// 			// upload_loadstart (the upload begins)
-			// 			xhr.upload.addEventListener("loadstart", upload_loadstart, false);
+		// 		// upload
+		// 			// upload_loadstart (the upload begins)
+		// 			xhr.upload.addEventListener("loadstart", upload_loadstart, false);
 
-			// 			// upload_load file (the upload ends successfully)
-			// 			xhr.upload.addEventListener("load", upload_load, false);
+		// 			// upload_load file (the upload ends successfully)
+		// 			xhr.upload.addEventListener("load", upload_load, false);
 
-			// 			// upload_error (the upload ends in error)
-			// 			xhr.upload.addEventListener("error", upload_error, false);
+		// 			// upload_error (the upload ends in error)
+		// 			xhr.upload.addEventListener("error", upload_error, false);
 
-			// 			// upload_abort (the upload has been aborted by the user)
-			// 			xhr.upload.addEventListener("abort", upload_abort, false);
+		// 			// upload_abort (the upload has been aborted by the user)
+		// 			xhr.upload.addEventListener("abort", upload_abort, false);
 
-			// 			// progress
-			// 			xhr.upload.addEventListener("progress", upload_progress, false);
+		// 			// progress
+		// 			xhr.upload.addEventListener("progress", upload_progress, false);
 
-			// 		// hxr
-			// 			// xhr_load (the XMLHttpRequest ends successfully)
-			// 			xhr.addEventListener("load", xhr_load, false);
+		// 		// hxr
+		// 			// xhr_load (the XMLHttpRequest ends successfully)
+		// 			xhr.addEventListener("load", xhr_load, false);
 
-			// 			// open connection
-			// 			xhr.open("POST", api_url, true);
+		// 			// open connection
+		// 			xhr.open("POST", api_url, true);
 
-			// 			// request header
-			// 			xhr.setRequestHeader("X-File-Name", encodeURIComponent(file.name));
+		// 			// request header
+		// 			xhr.setRequestHeader("X-File-Name", encodeURIComponent(file.name));
 
-			// 		// send data
-			// 			xhr.send(fd);
-	})//end promise
+		// 		// send data
+		// 			xhr.send(fd);
+})//end promise
 }//end upload
 
 
@@ -549,45 +549,50 @@ export const upload = async function(options) {
 */
 service_upload.prototype.upload_file = async function(options) {
 
-	const self = this
+const self = this
 
-	// options
-		const file = options.file
+// options
+	const file = options.file;
+	const ocr = options.ocr;
+	const lg = options.lg;
 
-	// short vars
-		const allowed_extensions	= self.allowed_extensions
-		const key_dir				= self.key_dir
-			? self.key_dir
-			: self.caller.context.features && self.caller.context.features.key_dir
-				? self.caller.context.features.key_dir
-				: self.caller.caller.context.features && self.caller.caller.context.features.key_dir
-					? self.caller.caller.context.features.key_dir
-					: (self.caller.caller.model || null) // like 'image'
 
-	// upload (using service upload)
-		const api_response = await upload({
-			id					: self.id, // id done by the caller, used to send the events of progress
-			file				: file, // object {name:'xxx.jpg',size:5456456}
-			key_dir				: key_dir, // string like 'image' used to target dir
-			allowed_extensions	: allowed_extensions, // array ['tiff', 'jpeg']
-			max_size_bytes		: self.max_size_bytes, // int 352142
-			tipo				: self.caller.caller?.tipo || null
-		})
-		if (!api_response.result) {
-			console.error("Error on api_response:", api_response);
-			return {
-				result	: false,
-				msg		: api_response.msg || 'Error on api_response'
-			}
+// short vars
+	const allowed_extensions	= self.allowed_extensions
+	const key_dir				= self.key_dir
+		? self.key_dir
+		: self.caller.context.features && self.caller.context.features.key_dir
+			? self.caller.context.features.key_dir
+			: self.caller.caller.context.features && self.caller.caller.context.features.key_dir
+				? self.caller.caller.context.features.key_dir
+				: (self.caller.caller.model || null) // like 'image'
+
+// upload (using service upload)
+	const api_response = await upload({
+		id					: self.id, // id done by the caller, used to send the events of progress
+		file				: file, // object {name:'xxx.jpg',size:5456456}
+		key_dir				: key_dir, // string like 'image' used to target dir
+		allowed_extensions	: allowed_extensions, // array ['tiff', 'jpeg']
+		max_size_bytes		: self.max_size_bytes, // int 352142
+		tipo				: self.caller.caller?.tipo || null
+	})
+	if (!api_response.result) {
+		console.error("Error on api_response:", api_response);
+		return {
+			result	: false,
+			msg		: api_response.msg || 'Error on api_response'
 		}
+	}
 
-	// event upload_file_done_
-		event_manager.publish('upload_file_done_' + self.caller.id, {
-			file_data : api_response.file_data
-		})
+// event upload_file_done_
+	event_manager.publish('upload_file_done_' + self.caller.id, {
+		file_data : api_response.file_data,
+		ocr : ocr,
+		lg : lg
+	})
 
 
-	return api_response
+return api_response
 }//end upload_file
 
 
@@ -601,33 +606,33 @@ service_upload.prototype.upload_file = async function(options) {
 */
 service_upload.prototype.join_chunked_files = async function(options) {
 
-	// options
-		const file_data		= options.file_data
-		const files_chunked	= options.files_chunked
+// options
+	const file_data		= options.file_data
+	const files_chunked	= options.files_chunked
 
-	// rqo
-		const rqo = {
-			dd_api	: 'dd_utils_api',
-			action	: 'join_chunked_files_uploaded',
-			options	: {
-				file_data		: file_data,
-				files_chunked	: files_chunked
-			}
+// rqo
+	const rqo = {
+		dd_api	: 'dd_utils_api',
+		action	: 'join_chunked_files_uploaded',
+		options	: {
+			file_data		: file_data,
+			files_chunked	: files_chunked
 		}
+	}
 
-	// call to the API, fetch data and get response
-		return new Promise(function(resolve){
+// call to the API, fetch data and get response
+	return new Promise(function(resolve){
 
-			data_manager.request({
-				body : rqo
-			})
-			.then(function(response){
-				if(SHOW_DEVELOPER===true) {
-					dd_console("-> get_system_info API response:",'DEBUG',response);
-				}
-				resolve(response)
-			})
+		data_manager.request({
+			body : rqo
 		})
+		.then(function(response){
+			if(SHOW_DEVELOPER===true) {
+				dd_console("-> get_system_info API response:",'DEBUG',response);
+			}
+			resolve(response)
+		})
+	})
 }//end get_system_info
 
 

--- a/tools/tool_upload/class.tool_upload.php
+++ b/tools/tool_upload/class.tool_upload.php
@@ -28,6 +28,8 @@ class tool_upload extends tool_common {
 
 		// options
 			$file_data		= $options->file_data;
+			$ocr			= $options->ocr;
+			$lg				= $options->lg;
 			$tipo			= $options->tipo ?? null;
 			$section_tipo	= $options->section_tipo;
 			$section_id		= $options->section_id ?? null;
@@ -68,6 +70,39 @@ class tool_upload extends tool_common {
 							$section_tipo
 						);
 
+					// OCR Processing
+						if($ocr===1){
+							$tmp_file_location = 
+										// httpdocs route
+										dirname($_SERVER['DOCUMENT_ROOT']).
+										// Route to tmp file location using a substring of the thumbnail location in $file_data->thumbnail_url
+										substr($file_data->thumbnail_url,0,strpos($file_data->thumbnail_url,"thumbnail/")-strlen($file_data->thumbnail_url)).
+										// Name of the tmp file
+										$file_data->tmp_name;
+
+							switch($lg) {
+								case 'lg-spa':
+									$lang = 'spa';
+									break;
+								case 'lg-vlca':
+									$lang = 'cat';
+									break;
+								case 'lg-fra':
+									$lang = 'fra';
+									break;
+								case 'lg-ita':
+									$lang = 'ita';
+									break;
+								case 'lg-eng':
+								default:
+									$lang = 'eng';
+									break;
+							}
+							
+							shell_exec("ocrmypdf -l ".$lang." --force-ocr ".$tmp_file_location." ".$tmp_file_location);
+						}
+							
+						
 					// fix current component target quality (defines the destination directory for the file, like 'original')
 						$component->set_quality($quality);
 

--- a/tools/tool_upload/js/render_tool_upload.js
+++ b/tools/tool_upload/js/render_tool_upload.js
@@ -5,9 +5,9 @@
 
 
 // imports
-	import {event_manager} from '../../../core/common/js/event_manager.js'
-	import {get_instance, delete_instance} from '../../../core/common/js/instances.js'
-	import {ui} from '../../../core/common/js/ui.js'
+import {event_manager} from '../../../core/common/js/event_manager.js'
+import {get_instance, delete_instance} from '../../../core/common/js/instances.js'
+import {ui} from '../../../core/common/js/ui.js'
 
 
 
@@ -17,7 +17,7 @@
 */
 export const render_tool_upload = function() {
 
-	return true
+return true
 }//end render_tool_upload
 
 
@@ -30,49 +30,49 @@ export const render_tool_upload = function() {
 */
 render_tool_upload.prototype.edit = async function (options) {
 
-	const self = this
+const self = this
 
-	// options
-		const render_level = options.render_level || 'full'
+// options
+	const render_level = options.render_level || 'full'
 
-	// content_data
-		const content_data = get_content_data(self)
-		if (render_level==='content') {
-			return content_data
-		}
+// content_data
+	const content_data = get_content_data(self)
+	if (render_level==='content') {
+		return content_data
+	}
 
-	// wrapper. ui build_edit returns component wrapper
-		const wrapper = ui.tool.build_wrapper_edit(self, {
-			content_data : content_data
+// wrapper. ui build_edit returns component wrapper
+	const wrapper = ui.tool.build_wrapper_edit(self, {
+		content_data : content_data
+	})
+
+// service_upload
+	// Use the service_upload to get and render the button to upload the file,
+	// get functionality defined (drag, drop, create folder, etc..)
+	// service_upload_container
+	const service_upload_container = ui.create_dom_element({
+		element_type	: 'div',
+		class_name		: 'service_upload_container'
+	})
+	wrapper.tool_header.after(service_upload_container)
+	// spinner
+	const spinner = ui.create_dom_element({
+		element_type	: 'div',
+		class_name		: "spinner",
+		parent			: service_upload_container
+	})
+	// service_upload. Build and render
+	self.service_upload.build()
+	.then(function(){
+		self.service_upload.render()
+		.then(function(tool_upload_node){
+			service_upload_container.appendChild(tool_upload_node)
+			spinner.remove()
 		})
-
-	// service_upload
-		// Use the service_upload to get and render the button to upload the file,
-		// get functionality defined (drag, drop, create folder, etc..)
-		// service_upload_container
-		const service_upload_container = ui.create_dom_element({
-			element_type	: 'div',
-			class_name		: 'service_upload_container'
-		})
-		wrapper.tool_header.after(service_upload_container)
-		// spinner
-		const spinner = ui.create_dom_element({
-			element_type	: 'div',
-			class_name		: "spinner",
-			parent			: service_upload_container
-		})
-		// service_upload. Build and render
-		self.service_upload.build()
-		.then(function(){
-			self.service_upload.render()
-			.then(function(tool_upload_node){
-				service_upload_container.appendChild(tool_upload_node)
-				spinner.remove()
-			})
-		})
+	})
 
 
-	return wrapper
+return wrapper
 }//end edit
 
 
@@ -84,31 +84,31 @@ render_tool_upload.prototype.edit = async function (options) {
 */
 export const get_content_data = function(self) {
 
-	const fragment = new DocumentFragment()
+const fragment = new DocumentFragment()
 
-	// process_file
-		const process_file = ui.create_dom_element({
-			element_type	: 'div',
-			class_name		: 'process_file',
-			parent			: fragment
-		})
-		self.process_file = process_file
+// process_file
+	const process_file = ui.create_dom_element({
+		element_type	: 'div',
+		class_name		: 'process_file',
+		parent			: fragment
+	})
+	self.process_file = process_file
 
-	// preview_component_container
-		const preview_component_container = ui.create_dom_element({
-			element_type	: 'div',
-			class_name		: 'preview_component_container',
-			parent			: fragment
-		})
-		// fix
-		self.preview_component_container = preview_component_container
+// preview_component_container
+	const preview_component_container = ui.create_dom_element({
+		element_type	: 'div',
+		class_name		: 'preview_component_container',
+		parent			: fragment
+	})
+	// fix
+	self.preview_component_container = preview_component_container
 
-	// content_data
-		const content_data = ui.tool.build_content_data(self)
-		content_data.appendChild(fragment)
+// content_data
+	const content_data = ui.tool.build_content_data(self)
+	content_data.appendChild(fragment)
 
 
-	return content_data
+return content_data
 }//end get_content_data
 
 
@@ -122,123 +122,125 @@ export const get_content_data = function(self) {
 */
 render_tool_upload.prototype.upload_done = async function (options) {
 
-	const self = this
+const self = this
 
-	// options
-		const file_data = options.file_data
+// options
+	const file_data = options.file_data;
+	const ocr = options.ocr;
+	const lg = options.lg;
 
-	// process_file loading
-		while (self.process_file.firstChild) {
-			self.process_file.removeChild(self.process_file.firstChild);
-		}
-		const spinner = ui.create_dom_element({
-			element_type	: 'div',
-			class_name		: 'spinner',
-			parent			: self.process_file
-		})
-		const process_file_info = ui.create_dom_element({
-			element_type	: 'span',
-			inner_html		: 'Processing file..',
-			class_name		: 'info',
-			parent			: self.process_file
-		})
-		self.process_file.appendChild(spinner)
+// process_file loading
+	while (self.process_file.firstChild) {
+		self.process_file.removeChild(self.process_file.firstChild);
+	}
+	const spinner = ui.create_dom_element({
+		element_type	: 'div',
+		class_name		: 'spinner',
+		parent			: self.process_file
+	})
+	const process_file_info = ui.create_dom_element({
+		element_type	: 'span',
+		inner_html		: 'Processing file..',
+		class_name		: 'info',
+		parent			: self.process_file
+	})
+	self.process_file.appendChild(spinner)
 
-	// process uploaded file (move temp uploaded file to definitive location and name)
-		const response = await self.process_uploaded_file(file_data)
+// process uploaded file (move temp uploaded file to definitive location and name)
+	const response = await self.process_uploaded_file(file_data,ocr,lg)
 
-	// spinner remove
-		spinner.remove()
+// spinner remove
+	spinner.remove()
 
-	// reset classes
-		process_file_info.classList.remove('failed')
-		process_file_info.classList.remove('success')
+// reset classes
+	process_file_info.classList.remove('failed')
+	process_file_info.classList.remove('success')
 
-	// response ERROR case
-		if (!response.result) {
+// response ERROR case
+	if (!response.result) {
 
-			// ERROR case
-			process_file_info.innerHTML = response.msg || 'Error on processing file!'
-			process_file_info.classList.add('failed')
+		// ERROR case
+		process_file_info.innerHTML = response.msg || 'Error on processing file!'
+		process_file_info.classList.add('failed')
 
-			return false
-		}
+		return false
+	}
 
-	// response OK case
-		process_file_info.innerHTML = response.msg || 'Processing file done successfully.'
-		process_file_info.classList.add('success')
+// response OK case
+	process_file_info.innerHTML = response.msg || 'Processing file done successfully.'
+	process_file_info.classList.add('success')
 
-	// hide service_upload elements. To upload again, user must to reload the page
-		setTimeout(function(){
-			[self.service_upload.form, self.service_upload.progress_bar_container].map(el => el.classList.add('hide'));
-		}, 1)
+// hide service_upload elements. To upload again, user must to reload the page
+	setTimeout(function(){
+		[self.service_upload.form, self.service_upload.progress_bar_container].map(el => el.classList.add('hide'));
+	}, 1)
 
-	// preview_component_container
-		if (self.caller.type==='component') {
+// preview_component_container
+	if (self.caller.type==='component') {
 
-			// component_instance. Get instance and init, build
-			// Must be a new one, not use the caller instance to prevent problems
-			// with data update on build
-				const component_instance = await get_instance({
-					model			: self.caller.model,
-					mode			: 'edit',
-					view			: 'default',
-					permissions		: 1,
-					tipo			: self.caller.tipo,
-					section_tipo	: self.caller.section_tipo,
-					section_id		: self.caller.section_id,
-					lang			: self.caller.lang,
-					id_variant		: self.name + '_upload_' + self.caller.id, // id_variant prevents id conflicts
-					caller			: self // set current tool as component caller (to check if component is inside tool or not)
-				})
-				// add to tool instances to allow delete on destroy
-				self.ar_instances.push(component_instance)
-				// build
-				await component_instance.build(true)
+		// component_instance. Get instance and init, build
+		// Must be a new one, not use the caller instance to prevent problems
+		// with data update on build
+			const component_instance = await get_instance({
+				model			: self.caller.model,
+				mode			: 'edit',
+				view			: 'default',
+				permissions		: 1,
+				tipo			: self.caller.tipo,
+				section_tipo	: self.caller.section_tipo,
+				section_id		: self.caller.section_id,
+				lang			: self.caller.lang,
+				id_variant		: self.name + '_upload_' + self.caller.id, // id_variant prevents id conflicts
+				caller			: self // set current tool as component caller (to check if component is inside tool or not)
+			})
+			// add to tool instances to allow delete on destroy
+			self.ar_instances.push(component_instance)
+			// build
+			await component_instance.build(true)
 
-			// create_posterframe when viewer is rendered and viewer ready
-				if(typeof component_instance.create_posterframe==='function') {
+		// create_posterframe when viewer is rendered and viewer ready
+			if(typeof component_instance.create_posterframe==='function') {
 
-					// prevent to show previous posterframe using default image instead
-					component_instance.data.posterframe_url = page_globals.fallback_image
+				// prevent to show previous posterframe using default image instead
+				component_instance.data.posterframe_url = page_globals.fallback_image
 
-					// on viewer ready, create the posterframe from the viewer
-					event_manager.subscribe('viewer_ready_'+component_instance.id, function(element) {
-						console.log('creating posterframe ', component_instance.id);
-						component_instance.create_posterframe(element)
-						.then(function(response){
-							console.log('create_posterframe done. response:', response);
-						})
+				// on viewer ready, create the posterframe from the viewer
+				event_manager.subscribe('viewer_ready_'+component_instance.id, function(element) {
+					console.log('creating posterframe ', component_instance.id);
+					component_instance.create_posterframe(element)
+					.then(function(response){
+						console.log('create_posterframe done. response:', response);
 					})
-				}
+				})
+			}
 
-			// render component
-				const component_node = await component_instance.render()
+		// render component
+			const component_node = await component_instance.render()
 
-			// preview. add rendered component node
-				self.preview_component_container.appendChild(component_node)
+		// preview. add rendered component node
+			self.preview_component_container.appendChild(component_node)
 
-			// refresh the caller (in window opener). (!) Commented because tool_common already refresh on blur (close window)
-				// const source_window = window.opener || window
-				// if (source_window && source_window.page_globals && source_window.page_globals.component_active) {
-				// 	source_window.page_globals.component_active.refresh({
-				// 		refresh_id_base_lang : true
-				// 	})
-				// }
-		}
+		// refresh the caller (in window opener). (!) Commented because tool_common already refresh on blur (close window)
+			// const source_window = window.opener || window
+			// if (source_window && source_window.page_globals && source_window.page_globals.component_active) {
+			// 	source_window.page_globals.component_active.refresh({
+			// 		refresh_id_base_lang : true
+			// 	})
+			// }
+	}
 
-	// event to update the DOM elements of the instance
-		// console.log('self.caller.data:', self.caller);
-		// event_manager.publish('update_value_'+self.caller.id_base, {
-		// 	caller			: self.caller,
-		// 	changed_data	: component_instance.data.changed_data
-		// })
+// event to update the DOM elements of the instance
+	// console.log('self.caller.data:', self.caller);
+	// event_manager.publish('update_value_'+self.caller.id_base, {
+	// 	caller			: self.caller,
+	// 	changed_data	: component_instance.data.changed_data
+	// })
 
-	// caller update. (usually media component like component_image)
-		// self.caller.refresh() (!) Unnecessary because on close this tool window, component is refresh too
+// caller update. (usually media component like component_image)
+	// self.caller.refresh() (!) Unnecessary because on close this tool window, component is refresh too
 
 
-	return true
+return true
 }//end upload_done
 
 
@@ -247,103 +249,103 @@ render_tool_upload.prototype.upload_done = async function (options) {
 * RENDER_FILEDRAG
 * @return HTMLElement filedrag
 */
-	// export const render_filedrag = function(self) {
+// export const render_filedrag = function(self) {
 
-	// 	// filedrag node
-	// 		const filedrag = ui.create_dom_element({
-	// 			element_type	: 'label',
-	// 			class_name		: 'filedrag'
-	// 			// text_content	: 'Select a file to upload or drop it here', // get_label.select_a_file ||
-	// 			// parent		: form
-	// 		})
-	// 		filedrag.setAttribute('for','file_to_upload')
-	// 		filedrag.addEventListener("dragover", file_drag_hover, false);
-	// 		filedrag.addEventListener("dragleave", file_drag_hover, false);
-	// 		filedrag.addEventListener("drop", function(e){
+// 	// filedrag node
+// 		const filedrag = ui.create_dom_element({
+// 			element_type	: 'label',
+// 			class_name		: 'filedrag'
+// 			// text_content	: 'Select a file to upload or drop it here', // get_label.select_a_file ||
+// 			// parent		: form
+// 		})
+// 		filedrag.setAttribute('for','file_to_upload')
+// 		filedrag.addEventListener("dragover", file_drag_hover, false);
+// 		filedrag.addEventListener("dragleave", file_drag_hover, false);
+// 		filedrag.addEventListener("drop", function(e){
 
-	// 			// cancel event and hover styling
-	// 			file_drag_hover(e);
+// 			// cancel event and hover styling
+// 			file_drag_hover(e);
 
-	// 			// fetch FileList object
-	// 			const files = e.target.files || e.dataTransfer.files;
+// 			// fetch FileList object
+// 			const files = e.target.files || e.dataTransfer.files;
 
-	// 			// process all File objects
-	// 			// for (let i = 0; i < files.length; i++) {
+// 			// process all File objects
+// 			// for (let i = 0; i < files.length; i++) {
 
-	// 				// const file = files[i]
+// 				// const file = files[i]
 
-	// 				// parse file info
-	// 				// parse_local_file(file);
+// 				// parse file info
+// 				// parse_local_file(file);
 
-	// 				// upload
-	// 				// self.upload_file(file, content_data, response_msg, preview_image, progress_bar_container)
-
-
-	// 				const file = files[0] || null
-	// 				if (!file) {
-	// 					return false
-	// 				}
-
-	// 				file_selected(self, file)
-
-	// 				filedrag.classList.add('loading_file')
-
-	// 				// reset preview_image
-	// 				if (self.preview_image) {
-	// 					self.preview_image.src = ''
-	// 				}
-
-	// 				self.upload_file({
-	// 					file : file
-	// 				})
-	// 				.then(function(response){
-	// 					// show filedrag again
-	// 						filedrag.classList.remove('loading_file')
-
-	// 					// on success actions
-	// 						if (response.result===true) {
-	// 							if (response.preview_url && self.preview_image) {
-	// 								self.preview_image.src = response.preview_url
-	// 								self.caller.refresh()
-	// 							}
-	// 							self.response_msg.innerHTML = response.msg || 'OK. File uploaded'
-	// 						}else{
-	// 							self.response_msg.innerHTML = response.msg || 'Error on upload file'
-	// 						}
-	// 				})
-
-	// 				// break; // only one is allowed
-	// 			// }
-	// 		})
-	// 		// fix
-	// 		self.filedrag = filedrag
-
-	// 	// label icon
-	// 		ui.create_dom_element({
-	// 			element_type	: 'img',
-	// 			src				: DEDALO_TOOLS_URL + '/' + self.model + '/img/icon.svg',
-	// 			parent			: filedrag
-	// 		})
-
-	// 	// label text
-	// 		ui.create_dom_element({
-	// 			element_type	: 'span',
-	// 			class_name		: '',
-	// 			text_content	: 'Select or drop a file it here',
-	// 			parent			: filedrag
-	// 		})
-
-	// 	// filedrag
-	// 		// const filedrag = ui.create_dom_element({
-	// 		// 	element_type	: 'div',
-	// 		// 	class_name		: 'filedrag',
-	// 		// 	text_content 	: 'or drop a file here',
-	// 		// 	parent 			: form
-	// 		// })
+// 				// upload
+// 				// self.upload_file(file, content_data, response_msg, preview_image, progress_bar_container)
 
 
-	// 	return filedrag
-	// }//end render_filedrag
+// 				const file = files[0] || null
+// 				if (!file) {
+// 					return false
+// 				}
+
+// 				file_selected(self, file)
+
+// 				filedrag.classList.add('loading_file')
+
+// 				// reset preview_image
+// 				if (self.preview_image) {
+// 					self.preview_image.src = ''
+// 				}
+
+// 				self.upload_file({
+// 					file : file
+// 				})
+// 				.then(function(response){
+// 					// show filedrag again
+// 						filedrag.classList.remove('loading_file')
+
+// 					// on success actions
+// 						if (response.result===true) {
+// 							if (response.preview_url && self.preview_image) {
+// 								self.preview_image.src = response.preview_url
+// 								self.caller.refresh()
+// 							}
+// 							self.response_msg.innerHTML = response.msg || 'OK. File uploaded'
+// 						}else{
+// 							self.response_msg.innerHTML = response.msg || 'Error on upload file'
+// 						}
+// 				})
+
+// 				// break; // only one is allowed
+// 			// }
+// 		})
+// 		// fix
+// 		self.filedrag = filedrag
+
+// 	// label icon
+// 		ui.create_dom_element({
+// 			element_type	: 'img',
+// 			src				: DEDALO_TOOLS_URL + '/' + self.model + '/img/icon.svg',
+// 			parent			: filedrag
+// 		})
+
+// 	// label text
+// 		ui.create_dom_element({
+// 			element_type	: 'span',
+// 			class_name		: '',
+// 			text_content	: 'Select or drop a file it here',
+// 			parent			: filedrag
+// 		})
+
+// 	// filedrag
+// 		// const filedrag = ui.create_dom_element({
+// 		// 	element_type	: 'div',
+// 		// 	class_name		: 'filedrag',
+// 		// 	text_content 	: 'or drop a file here',
+// 		// 	parent 			: form
+// 		// })
+
+
+// 	return filedrag
+// }//end render_filedrag
 
 
 
@@ -351,168 +353,168 @@ render_tool_upload.prototype.upload_done = async function (options) {
 * FILE_SELECTED
 * Manages user drag file or user file selection
 */
-	// export const file_selected = async function(self, file) {
+// export const file_selected = async function(self, file) {
 
-	// 	self.filedrag.classList.add('loading_file')
+// 	self.filedrag.classList.add('loading_file')
 
-	// 	// reset preview_image if exists
-	// 		if (self.preview_image) {
-	// 			self.preview_image.src = ''
-	// 		}
+// 	// reset preview_image if exists
+// 		if (self.preview_image) {
+// 			self.preview_image.src = ''
+// 		}
 
-	// 	// upload file to server
-	// 		const response = await self.upload_file({
-	// 			file : file
-	// 		})
+// 	// upload file to server
+// 		const response = await self.upload_file({
+// 			file : file
+// 		})
 
-	// 	// show filedrag again
-	// 		self.filedrag.classList.remove('loading_file')
+// 	// show filedrag again
+// 		self.filedrag.classList.remove('loading_file')
 
-	// 	// on success actions
-	// 		if (response.result===true) {
-	// 			if (response.preview_url && self.preview_image) {
-	// 				self.preview_image.src = response.preview_url
-	// 			}
-	// 			self.caller.refresh()
-	// 			self.response_msg.innerHTML = response.msg || 'OK. File uploaded'
-	// 		}else{
-	// 			self.response_msg.innerHTML = response.msg || 'Error on upload file'
-	// 		}
+// 	// on success actions
+// 		if (response.result===true) {
+// 			if (response.preview_url && self.preview_image) {
+// 				self.preview_image.src = response.preview_url
+// 			}
+// 			self.caller.refresh()
+// 			self.response_msg.innerHTML = response.msg || 'OK. File uploaded'
+// 		}else{
+// 			self.response_msg.innerHTML = response.msg || 'Error on upload file'
+// 		}
 
 
-	// 	return response
-	// }//end file_selected
+// 	return response
+// }//end file_selected
 
 
 
 /**
 * RENDER_PROGRESS_BAR
 */
-	// export const render_progress_bar = function(self) {
+// export const render_progress_bar = function(self) {
 
-	// 	// progress_bar_container
-	// 		const progress_bar_container = ui.create_dom_element({
-	// 			element_type	: 'div',
-	// 			class_name		: 'progress_bar_container'
-	// 		})
+// 	// progress_bar_container
+// 		const progress_bar_container = ui.create_dom_element({
+// 			element_type	: 'div',
+// 			class_name		: 'progress_bar_container'
+// 		})
 
-	// 	// progress_info
-	// 		const progress_info = ui.create_dom_element({
-	// 			element_type	: 'div',
-	// 			class_name		: 'progress_info',
-	// 			parent 			: progress_bar_container
-	// 		})
-	// 		// fix
-	// 		self.progress_info = progress_info
+// 	// progress_info
+// 		const progress_info = ui.create_dom_element({
+// 			element_type	: 'div',
+// 			class_name		: 'progress_info',
+// 			parent 			: progress_bar_container
+// 		})
+// 		// fix
+// 		self.progress_info = progress_info
 
-	// 	// progress_line
-	// 		const progress_line = ui.create_dom_element({
-	// 			element_type	: 'progress',
-	// 			class_name		: 'progress_line',
-	// 			parent 			: progress_bar_container
-	// 		})
-	// 		progress_line.max   = 100;
-	// 		progress_line.value = 0;
-	// 		// fix
-	// 		self.progress_line = progress_line
+// 	// progress_line
+// 		const progress_line = ui.create_dom_element({
+// 			element_type	: 'progress',
+// 			class_name		: 'progress_line',
+// 			parent 			: progress_bar_container
+// 		})
+// 		progress_line.max   = 100;
+// 		progress_line.value = 0;
+// 		// fix
+// 		self.progress_line = progress_line
 
 
-	// 	return progress_bar_container
-	// }//end render_progress_bar
+// 	return progress_bar_container
+// }//end render_progress_bar
 
 
 
 /**
 * FILE_DRAG_HOVER
 */
-	// export const file_drag_hover = function(e) {
+// export const file_drag_hover = function(e) {
 
-	// 	e.stopPropagation();
-	// 	e.preventDefault();
+// 	e.stopPropagation();
+// 	e.preventDefault();
 
-	// 	if (e.type==="dragover") {
-	// 		e.target.classList.add("hover")
-	// 	}else{
-	// 		e.target.classList.remove("hover")
-	// 	}
+// 	if (e.type==="dragover") {
+// 		e.target.classList.add("hover")
+// 	}else{
+// 		e.target.classList.remove("hover")
+// 	}
 
-	// 	return true
-	// }//end file_drag_hover
+// 	return true
+// }//end file_drag_hover
 
 
 
 /**
 * FILE_SELECT_HANDLER
 */
-	// export const file_select_handler = function(e) {
+// export const file_select_handler = function(e) {
 
-	// 	// cancel event and hover styling
-	// 	file_drag_hover(e);
+// 	// cancel event and hover styling
+// 	file_drag_hover(e);
 
-	// 	// fetch FileList object
-	// 	const files = e.target.files || e.dataTransfer.files;
+// 	// fetch FileList object
+// 	const files = e.target.files || e.dataTransfer.files;
 
-	// 	// process all File objects
-	// 	for (let i = 0; i < files.length; i++) {
+// 	// process all File objects
+// 	for (let i = 0; i < files.length; i++) {
 
-	// 		const file = files[i]
+// 		const file = files[i]
 
-	// 		// parse file info
-	// 		// parse_local_file(file);
+// 		// parse file info
+// 		// parse_local_file(file);
 
-	// 		// upload
-	// 		self.upload_file(file, content_data, response_msg, preview_image, progress_bar_container)
+// 		// upload
+// 		self.upload_file(file, content_data, response_msg, preview_image, progress_bar_container)
 
-	// 		break; // only one is allowed
-	// 	}
+// 		break; // only one is allowed
+// 	}
 
-	// 	return true
-	// }//end file_select_handler
+// 	return true
+// }//end file_select_handler
 
 
 
 // Removed for the time being (!)
-	// // output information
-	// function msg_output(msg) {
-	// 	// file_info.innerHTML = msg + file_info.innerHTML;
-	// 	file_info.innerHTML += msg;
-	// }
+// // output information
+// function msg_output(msg) {
+// 	// file_info.innerHTML = msg + file_info.innerHTML;
+// 	file_info.innerHTML += msg;
+// }
 
-	// // output file information
-	// function parse_local_file(file) {
+// // output file information
+// function parse_local_file(file) {
 
-	// 	msg_output(
-	// 		"<div><span>Name:</span> <strong>" + file.name + "</strong></div>" +
-	// 		"<div><span>Type:</span> <strong>" + file.type + "</strong></div>" +
-	// 		"<div><span>Size:</span> <strong>" + parseInt(file.size/1024) + "</strong> Kbytes</div>"
-	// 	);
+// 	msg_output(
+// 		"<div><span>Name:</span> <strong>" + file.name + "</strong></div>" +
+// 		"<div><span>Type:</span> <strong>" + file.type + "</strong></div>" +
+// 		"<div><span>Size:</span> <strong>" + parseInt(file.size/1024) + "</strong> Kbytes</div>"
+// 	);
 
-	// 	// display an image
-	// 	if (file.type.indexOf("image") == 0) {
-	// 		var reader = new FileReader();
-	// 		reader.onload = function(e) {
-	// 			msg_output(
-	// 				'<div><img src="' + e.target.result + '" /></div>'
-	// 			);
-	// 		}
-	// 		reader.readAsDataURL(file);
-	// 	}
+// 	// display an image
+// 	if (file.type.indexOf("image") == 0) {
+// 		var reader = new FileReader();
+// 		reader.onload = function(e) {
+// 			msg_output(
+// 				'<div><img src="' + e.target.result + '" /></div>'
+// 			);
+// 		}
+// 		reader.readAsDataURL(file);
+// 	}
 
-	// 	// display text
-	// 	if (file.type.indexOf("text") == 0) {
-	// 		var reader = new FileReader();
-	// 		reader.onload = function(e) {
-	// 			msg_output(
-	// 				"<p><strong>" + file.name + ":</strong></p><pre>" +
-	// 				e.target.result.replace(/</g, "&lt;").replace(/>/g, "&gt;") +
-	// 				"</pre>"
-	// 			);
-	// 		}
-	// 		reader.readAsText(file);
-	// 	}
+// 	// display text
+// 	if (file.type.indexOf("text") == 0) {
+// 		var reader = new FileReader();
+// 		reader.onload = function(e) {
+// 			msg_output(
+// 				"<p><strong>" + file.name + ":</strong></p><pre>" +
+// 				e.target.result.replace(/</g, "&lt;").replace(/>/g, "&gt;") +
+// 				"</pre>"
+// 			);
+// 		}
+// 		reader.readAsText(file);
+// 	}
 
-	// 	return true
-	// }//end parse_local_file
+// 	return true
+// }//end parse_local_file
 
 
 

--- a/tools/tool_upload/js/tool_upload.js
+++ b/tools/tool_upload/js/tool_upload.js
@@ -5,14 +5,14 @@
 
 
 // import
-	import {get_instance, delete_instance} from '../../../core/common/js/instances.js'
-	import {clone, dd_console} from '../../../core/common/js/utils/index.js'
-	import {data_manager} from '../../../core/common/js/data_manager.js'
-	import {event_manager} from '../../../core/common/js/event_manager.js'
-	import {common, create_source} from '../../../core/common/js/common.js'
-	import {tool_common} from '../../tool_common/js/tool_common.js'
-	import {ui} from '../../../core/common/js/ui.js'
-	import {render_tool_upload} from './render_tool_upload.js'
+import {get_instance, delete_instance} from '../../../core/common/js/instances.js'
+import {clone, dd_console} from '../../../core/common/js/utils/index.js'
+import {data_manager} from '../../../core/common/js/data_manager.js'
+import {event_manager} from '../../../core/common/js/event_manager.js'
+import {common, create_source} from '../../../core/common/js/common.js'
+import {tool_common} from '../../tool_common/js/tool_common.js'
+import {ui} from '../../../core/common/js/ui.js'
+import {render_tool_upload} from './render_tool_upload.js'
 
 
 
@@ -22,17 +22,17 @@
 */
 export const tool_upload = function () {
 
-	this.id				= null
-	this.model			= null
-	this.mode			= null
-	this.node			= null
-	this.ar_instances	= null
-	this.status			= null
-	this.events_tokens	= null
-	this.type			= null
-	this.caller			= null
+this.id				= null
+this.model			= null
+this.mode			= null
+this.node			= null
+this.ar_instances	= null
+this.status			= null
+this.events_tokens	= null
+this.type			= null
+this.caller			= null
 
-	this.max_size_bytes	= null
+this.max_size_bytes	= null
 }//end tool_upload
 
 
@@ -42,13 +42,13 @@ export const tool_upload = function () {
 * extend component functions from component common
 */
 // prototypes assign
-	tool_upload.prototype.render		= tool_common.prototype.render
-	tool_upload.prototype.destroy		= common.prototype.destroy
-	tool_upload.prototype.refresh		= common.prototype.refresh
-	tool_upload.prototype.edit			= render_tool_upload.prototype.edit
-	tool_upload.prototype.list			= render_tool_upload.prototype.edit
-	tool_upload.prototype.mini			= render_tool_upload.prototype.edit
-	tool_upload.prototype.upload_done	= render_tool_upload.prototype.upload_done
+tool_upload.prototype.render		= tool_common.prototype.render
+tool_upload.prototype.destroy		= common.prototype.destroy
+tool_upload.prototype.refresh		= common.prototype.refresh
+tool_upload.prototype.edit			= render_tool_upload.prototype.edit
+tool_upload.prototype.list			= render_tool_upload.prototype.edit
+tool_upload.prototype.mini			= render_tool_upload.prototype.edit
+tool_upload.prototype.upload_done	= render_tool_upload.prototype.upload_done
 
 
 
@@ -59,21 +59,21 @@ export const tool_upload = function () {
 */
 tool_upload.prototype.init = async function(options) {
 
-	const self = this
+const self = this
 
-	// call the generic common tool init
-		const common_init = await tool_common.prototype.init.call(this, options);
+// call the generic common tool init
+	const common_init = await tool_common.prototype.init.call(this, options);
 
-	// events
-		self.events_tokens.push(
-			event_manager.subscribe('upload_file_done_' + self.id, fn_upload_manage)
-		)
-		function fn_upload_manage(options) {
-			return self.upload_done(options)
-		}
+// events
+	self.events_tokens.push(
+		event_manager.subscribe('upload_file_done_' + self.id, fn_upload_manage)
+	)
+	function fn_upload_manage(options) {
+		return self.upload_done(options)
+	}
 
 
-	return common_init
+return common_init
 }//end init
 
 
@@ -85,31 +85,31 @@ tool_upload.prototype.init = async function(options) {
 */
 tool_upload.prototype.build = async function(autoload=false) {
 
-	const self = this
+const self = this
 
-	// call generic common tool build
-		const common_build = await tool_common.prototype.build.call(this, autoload);
+// call generic common tool build
+	const common_build = await tool_common.prototype.build.call(this, autoload);
 
-	try {
+try {
 
-		// service_upload
-			// get instance and init
-			self.service_upload = await get_instance({
-				model				: 'service_upload',
-				mode				: 'edit',
-				allowed_extensions	: self.caller.context.features.allowed_extensions, // like ['csv','jpg']
-				caller				: self
-			})
-			// console.log("self.service_upload:",self.service_upload);
-			self.ar_instances.push(self.service_upload)
+	// service_upload
+		// get instance and init
+		self.service_upload = await get_instance({
+			model				: 'service_upload',
+			mode				: 'edit',
+			allowed_extensions	: self.caller.context.features.allowed_extensions, // like ['csv','jpg']
+			caller				: self
+		})
+		// console.log("self.service_upload:",self.service_upload);
+		self.ar_instances.push(self.service_upload)
 
-	} catch (error) {
-		self.error = error
-		console.error(error)
-	}
+} catch (error) {
+	self.error = error
+	console.error(error)
+}
 
 
-	return common_build
+return common_build
 }//end build_custom
 
 
@@ -129,48 +129,50 @@ tool_upload.prototype.build = async function(autoload=false) {
 * @return promise
 * 	Resolve: object API response
 */
-tool_upload.prototype.process_uploaded_file = function(file_data) {
+tool_upload.prototype.process_uploaded_file = function(file_data,ocr,lg) {
 
-	const self = this
+const self = this
 
-	// source. Note that second argument is the name of the function to manage the tool request like 'apply_value'
-	// this generates a call as my_tool_name::my_function_name(options)
-		const source = create_source(self, 'process_uploaded_file')
+// source. Note that second argument is the name of the function to manage the tool request like 'apply_value'
+// this generates a call as my_tool_name::my_function_name(options)
+	const source = create_source(self, 'process_uploaded_file')
 
-	// rqo
-		const rqo = {
-			dd_api	: 'dd_tools_api',
-			action	: 'tool_request',
-			source	: source,
-			options	: {
-				file_data		: file_data,
-				tipo			: self.caller.tipo,
-				section_tipo	: self.caller.section_tipo,
-				section_id		: self.caller.section_id,
-				caller_type		: self.caller.context.type, // like 'tool' or 'component'. Switch different process actions on tool_upload class
-				quality			: self.caller.context.target_quality || self.caller.context.features.default_target_quality || null, // only for components
-				target_dir		: self.caller.context.target_dir || null // optional object like {type: 'dedalo_config', value: 'DEDALO_TOOL_IMPORT_DEDALO_CSV_FOLDER_PATH' // defined in config}
-			}
+// rqo
+	const rqo = {
+		dd_api	: 'dd_tools_api',
+		action	: 'tool_request',
+		source	: source,
+		options	: {
+			file_data		: file_data,
+				ocr			: ocr,
+				lg			: lg,
+			tipo			: self.caller.tipo,
+			section_tipo	: self.caller.section_tipo,
+			section_id		: self.caller.section_id,
+			caller_type		: self.caller.context.type, // like 'tool' or 'component'. Switch different process actions on tool_upload class
+			quality			: self.caller.context.target_quality || self.caller.context.features.default_target_quality || null, // only for components
+			target_dir		: self.caller.context.target_dir || null // optional object like {type: 'dedalo_config', value: 'DEDALO_TOOL_IMPORT_DEDALO_CSV_FOLDER_PATH' // defined in config}
 		}
+	}
 
-	// call to the API, fetch data and get response
-		return new Promise(function(resolve){
+// call to the API, fetch data and get response
+	return new Promise(function(resolve){
 
-			data_manager.request({
-				body : rqo
-			})
-			.then(function(api_response){
-				if(SHOW_DEVELOPER===true) {
-					dd_console("-> process_uploaded_file API api_response:",'DEBUG', api_response);
-				}
-
-				// events
-					event_manager.publish('process_uploaded_file_done_' + self.id, api_response)
-
-
-				resolve(api_response)
-			})
+		data_manager.request({
+			body : rqo
 		})
+		.then(function(api_response){
+			if(SHOW_DEVELOPER===true) {
+				dd_console("-> process_uploaded_file API api_response:",'DEBUG', api_response);
+			}
+
+			// events
+				event_manager.publish('process_uploaded_file_done_' + self.id, api_response)
+
+
+			resolve(api_response)
+		})
+	})
 }//end process_uploaded_file
 
 


### PR DESCRIPTION
Hi,

We have developed a functionality to apply OCR (image to text conversion) to PDFs that are uploaded to Dedalo.
When uploading a pdf, the option to apply OCR or not and a drop-down menu to select the OCR language is shown.

To do this, we use the ocrmypdf tool, which must be installed on the same server as Dedalo, since it is invoked from Dedalo via the shell_exec function.

We would like you to review these changes so that they can be incorporated into the official Dedalo code and that they can be used in any Dedalo installation, since we consider that it is a functionality that can be quite interesting for any area.

Above all, we are interested in the revision of the tool_upload file class.tool_upload.php. Both the way of obtaining the path of the file to be uploaded and the conversion between the Dedalo languages and the OCR languages, which we do manually, we think can be greatly improved. As well as anything else that you consider can be improved or optimized.

We can comment on what you need about it.

We hope this is of interest to the community and can be incorporated into the official Dedalo distribution.

Best